### PR TITLE
[OPE-9] feat(inventory): Implement low stock alerts

### DIFF
--- a/backend/catalog/api.ts
+++ b/backend/catalog/api.ts
@@ -215,6 +215,7 @@ interface CreateVariantRequest {
   price_cents: number;
   cost_cents?: number;
   active?: boolean;
+  low_stock_threshold?: number;
 }
 
 interface UpdateVariantRequest {
@@ -223,6 +224,7 @@ interface UpdateVariantRequest {
   price_cents?: number;
   cost_cents?: number;
   active?: boolean;
+  low_stock_threshold?: number;
 }
 
 interface VariantResponse {
@@ -233,6 +235,7 @@ interface VariantResponse {
   price_cents: number;
   cost_cents: number;
   active: boolean;
+  low_stock_threshold: number;
 }
 
 export const createVariant = api(
@@ -260,6 +263,7 @@ export const createVariant = api(
       price_cents: req.price_cents,
       cost_cents: req.cost_cents ?? 0,
       active: req.active ?? true,
+      low_stock_threshold: req.low_stock_threshold ?? 10,
     });
     await variantRepo.save(variant);
     return {
@@ -270,6 +274,7 @@ export const createVariant = api(
       price_cents: variant.price_cents,
       cost_cents: variant.cost_cents,
       active: variant.active,
+      low_stock_threshold: variant.low_stock_threshold,
     };
   }
 );
@@ -291,6 +296,7 @@ export const listVariants = api(
         price_cents: v.price_cents,
         cost_cents: v.cost_cents,
         active: v.active,
+        low_stock_threshold: v.low_stock_threshold,
       })),
     };
   }
@@ -322,6 +328,7 @@ export const updateVariant = api(
     if (req.price_cents !== undefined) variant.price_cents = req.price_cents;
     if (req.cost_cents !== undefined) variant.cost_cents = req.cost_cents;
     if (req.active !== undefined) variant.active = req.active;
+    if (req.low_stock_threshold !== undefined) variant.low_stock_threshold = req.low_stock_threshold;
 
     await variantRepo.save(variant);
     return {
@@ -332,6 +339,7 @@ export const updateVariant = api(
       price_cents: variant.price_cents,
       cost_cents: variant.cost_cents,
       active: variant.active,
+      low_stock_threshold: variant.low_stock_threshold,
     };
   }
 );

--- a/backend/catalog/entities.ts
+++ b/backend/catalog/entities.ts
@@ -91,6 +91,9 @@ export class Variant {
   @Column({ type: "boolean", default: true })
   active: boolean;
 
+  @Column({ name: "low_stock_threshold", type: "integer", default: 10 })
+  low_stock_threshold: number;
+
   @CreateDateColumn({ name: "created_at" })
   created_at: Date;
 

--- a/backend/catalog/migrations/2_add_low_stock_threshold.up.sql
+++ b/backend/catalog/migrations/2_add_low_stock_threshold.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE variants ADD COLUMN low_stock_threshold INTEGER NOT NULL DEFAULT 10;

--- a/backend/inventory/api.ts
+++ b/backend/inventory/api.ts
@@ -1,6 +1,7 @@
 import { api } from "encore.dev/api";
 import { getDataSource } from "./datasource";
 import { InventoryLedger, InventorySnapshot } from "./entities";
+import { Product, Variant } from "../catalog/entities";
 import { requireRole } from "../auth/middleware";
 
 interface LedgerRequest {
@@ -124,5 +125,77 @@ export const getStock = api(
       balance,
       snapshot_at: latestSnapshot ? latestSnapshot.snapshot_at.toISOString() : null,
     };
+  }
+);
+
+interface LowStockVariant {
+  variant_id: string;
+  sku: string;
+  barcode: string | null;
+  product_id: string;
+  product_name: string;
+  balance: number;
+  threshold: number;
+  status: "low" | "out";
+}
+
+interface LowStockResponse {
+  variants: LowStockVariant[];
+}
+
+async function getVariantBalance(ds: Awaited<ReturnType<typeof getDataSource>>, variantId: string): Promise<number> {
+  const snapshotRepo = ds.getRepository(InventorySnapshot);
+  const ledgerRepo = ds.getRepository(InventoryLedger);
+
+  const latestSnapshot = await snapshotRepo.findOne({
+    where: { variant_id: variantId },
+    order: { snapshot_at: "DESC" },
+  });
+
+  let balance = latestSnapshot ? latestSnapshot.balance : 0;
+  const since = latestSnapshot ? latestSnapshot.snapshot_at : new Date(0);
+
+  const result = await ledgerRepo
+    .createQueryBuilder("ledger")
+    .select("SUM(ledger.delta)", "sum")
+    .where("ledger.variant_id = :id", { id: variantId })
+    .andWhere("ledger.created_at > :since", { since })
+    .getRawOne();
+
+  const deltaSum = parseInt(result?.sum || "0", 10);
+  return balance + deltaSum;
+}
+
+export const getLowStock = api(
+  { expose: true, method: "GET", path: "/inventory/low-stock", auth: true },
+  async (req: { threshold?: number }): Promise<LowStockResponse> => {
+    const ds = await getDataSource();
+    const variantRepo = ds.getRepository(Variant);
+    const productRepo = ds.getRepository(Product);
+
+    const variants = await variantRepo.find();
+
+    const lowStockVariants: LowStockVariant[] = [];
+
+    for (const variant of variants) {
+      const balance = await getVariantBalance(ds, variant.id);
+      const effectiveThreshold = req.threshold ?? variant.low_stock_threshold;
+
+      if (balance <= effectiveThreshold) {
+        const product = await productRepo.findOne({ where: { id: variant.product_id } });
+        lowStockVariants.push({
+          variant_id: variant.id,
+          sku: variant.sku,
+          barcode: variant.barcode,
+          product_id: variant.product_id,
+          product_name: product?.name ?? "Unknown Product",
+          balance,
+          threshold: effectiveThreshold,
+          status: balance === 0 ? "out" : "low",
+        });
+      }
+    }
+
+    return { variants: lowStockVariants };
   }
 );

--- a/backend/inventory/datasource.ts
+++ b/backend/inventory/datasource.ts
@@ -1,6 +1,7 @@
 import { DataSource } from "typeorm";
 import { inventoryDB } from "./encore.service";
 import { InventoryLedger, InventorySnapshot } from "./entities";
+import { Product, Variant } from "../catalog/entities";
 
 let dataSource: DataSource | null = null;
 
@@ -10,7 +11,7 @@ export async function getDataSource(): Promise<DataSource> {
   dataSource = new DataSource({
     type: "postgres",
     url: inventoryDB.connectionString,
-    entities: [InventoryLedger, InventorySnapshot],
+    entities: [InventoryLedger, InventorySnapshot, Product, Variant],
     synchronize: false,
   });
 

--- a/frontend/src/components/pos/low-stock-badge.tsx
+++ b/frontend/src/components/pos/low-stock-badge.tsx
@@ -1,0 +1,29 @@
+import { Badge } from '@/components/ui/badge'
+
+interface LowStockBadgeProps {
+  status: 'low' | 'out'
+  balance: number
+  threshold: number
+}
+
+export function LowStockBadge({ status, balance, threshold }: LowStockBadgeProps) {
+  if (status === 'out') {
+    return (
+      <Badge
+        variant="destructive"
+        className="absolute top-2 right-2"
+      >
+        OUT ({balance})
+      </Badge>
+    )
+  }
+
+  return (
+    <Badge
+      variant="secondary"
+      className="absolute top-2 right-2 bg-amber-100 text-amber-800 border-amber-300 hover:bg-amber-100"
+    >
+      LOW ({balance}/{threshold})
+    </Badge>
+  )
+}

--- a/frontend/src/components/pos/product-grid.tsx
+++ b/frontend/src/components/pos/product-grid.tsx
@@ -1,14 +1,15 @@
 import { ProductTile } from './product-tile'
-import type { ProductResponse, VariantResponse } from '@/lib/api-client'
+import type { LowStockVariant, ProductResponse, VariantResponse } from '@/lib/api-client'
 
 interface ProductGridProps {
   products: ProductResponse[]
   variantsByProduct: Record<string, VariantResponse[]>
   onAddToCart: (variant: VariantResponse) => void
   isLoading?: boolean
+  lowStockInfo?: Record<string, LowStockVariant>
 }
 
-export function ProductGrid({ products, variantsByProduct, onAddToCart, isLoading }: ProductGridProps) {
+export function ProductGrid({ products, variantsByProduct, onAddToCart, isLoading, lowStockInfo }: ProductGridProps) {
   if (isLoading) {
     return (
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 p-4">
@@ -36,6 +37,7 @@ export function ProductGrid({ products, variantsByProduct, onAddToCart, isLoadin
           product={product}
           variants={variantsByProduct[product.id] || []}
           onAddToCart={onAddToCart}
+          lowStockInfo={lowStockInfo}
         />
       ))}
     </div>

--- a/frontend/src/components/pos/product-tile.tsx
+++ b/frontend/src/components/pos/product-tile.tsx
@@ -1,28 +1,36 @@
 import { Card } from '@/components/ui/card'
 import { formatTHB } from '@/lib/format'
-import type { ProductResponse, VariantResponse } from '@/lib/api-client'
+import type { LowStockVariant, ProductResponse, VariantResponse } from '@/lib/api-client'
+import { LowStockBadge } from './low-stock-badge'
 
 interface ProductTileProps {
   product: ProductResponse
   variants: VariantResponse[]
   onAddToCart: (variant: VariantResponse) => void
+  lowStockInfo?: Record<string, LowStockVariant>
 }
 
-export function ProductTile({ product, variants, onAddToCart }: ProductTileProps) {
+export function ProductTile({ product, variants, onAddToCart, lowStockInfo }: ProductTileProps) {
   const activeVariants = variants.filter(v => v.active)
   const primaryVariant = activeVariants[0]
 
   if (!primaryVariant) return null
 
+  const hasLowStockVariant = Object.values(lowStockInfo || {}).some(
+    (lsv) => lsv.product_id === product.id
+  )
+  const primaryLowStock = primaryVariant ? lowStockInfo?.[primaryVariant.id] : undefined
+
   return (
     <Card
-      className="p-3 cursor-pointer active:scale-[0.97] transition-transform touch-manipulation"
+      className="p-3 cursor-pointer active:scale-[0.97] transition-transform touch-manipulation relative"
       onClick={() => {
         if (activeVariants.length === 1) {
           onAddToCart(primaryVariant)
         }
       }}
     >
+      {primaryLowStock && <LowStockBadge {...primaryLowStock} />}
       <div className="aspect-square bg-surface rounded-md mb-2 flex items-center justify-center">
         <span className="text-2xl text-zinc-300">📦</span>
       </div>

--- a/frontend/src/hooks/use-catalog.ts
+++ b/frontend/src/hooks/use-catalog.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchCategories, fetchProducts, fetchVariants } from '@/lib/api-client';
+import { fetchCategories, fetchProducts, fetchVariants, fetchLowStock } from '@/lib/api-client';
 
 export function useCategories() {
   return useQuery({
@@ -28,5 +28,12 @@ export function useVariants(productId: string) {
     queryKey: ['variants', productId],
     queryFn: () => fetchVariants(productId).then(r => r.variants),
     enabled: !!productId,
+  });
+}
+
+export function useLowStockVariants(threshold?: number) {
+  return useQuery({
+    queryKey: ['low-stock', { threshold }],
+    queryFn: () => fetchLowStock(threshold).then(r => r.variants),
   });
 }

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -64,6 +64,18 @@ export interface VariantResponse {
   price_cents: number;
   cost_cents: number;
   active: boolean;
+  low_stock_threshold: number;
+}
+
+export interface LowStockVariant {
+  variant_id: string;
+  sku: string;
+  barcode: string | null;
+  product_id: string;
+  product_name: string;
+  balance: number;
+  threshold: number;
+  status: "low" | "out";
 }
 
 // Catalog endpoints
@@ -81,4 +93,19 @@ export function fetchProducts(params?: { category_id?: string; search?: string }
 
 export function fetchVariants(productId: string) {
   return apiFetch<{ variants: VariantResponse[] }>(`/catalog/products/${productId}/variants`);
+}
+
+export function updateVariant(id: string, data: { low_stock_threshold?: number }) {
+  return apiFetch<VariantResponse>(`/catalog/variants/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  });
+}
+
+// Inventory endpoints
+export function fetchLowStock(threshold?: number) {
+  const query = new URLSearchParams();
+  if (threshold !== undefined) query.set('threshold', String(threshold));
+  const qs = query.toString();
+  return apiFetch<{ variants: LowStockVariant[] }>(`/inventory/low-stock${qs ? `?${qs}` : ''}`);
 }

--- a/frontend/src/routes/pos/index.tsx
+++ b/frontend/src/routes/pos/index.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { useCategories, useProducts, useSearchProducts } from '@/hooks/use-catalog'
+import { useCategories, useProducts, useSearchProducts, useLowStockVariants } from '@/hooks/use-catalog'
 import { useDebouncedValue } from '@/hooks/use-debounce'
 import { fetchProducts, fetchVariants, type VariantResponse } from '@/lib/api-client'
 import { SearchBar } from '@/components/pos/search-bar'
@@ -12,6 +12,7 @@ import { ProductGrid } from '@/components/pos/product-grid'
 import { CartSummaryBar } from '@/components/pos/cart-summary-bar'
 import { CartBottomSheet } from '@/components/pos/cart-bottom-sheet'
 import { BarcodeScanner } from '@/components/pos/barcode-scanner'
+import { Button } from '@/components/ui/button'
 import { useKeyboardWedge } from '@/hooks/use-keyboard-wedge'
 import { useCartStore } from '@/stores/cart-store'
 
@@ -23,6 +24,7 @@ function POSScreen() {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
   const [scannerOpen, setScannerOpen] = useState(false)
+  const [showLowStockOnly, setShowLowStockOnly] = useState(false)
 
   const debouncedSearch = useDebouncedValue(searchQuery, 300)
 
@@ -31,23 +33,37 @@ function POSScreen() {
     selectedCategory ?? undefined
   )
   const { data: searchResults = [], isLoading: isSearchLoading } = useSearchProducts(debouncedSearch)
+  const { data: lowStockVariants = [] } = useLowStockVariants()
 
   const isSearching = searchQuery.length >= 2
   const displayProducts = isSearching ? searchResults : browseProducts
   const isLoading = isSearching ? isSearchLoading : isBrowseLoading
 
+  const lowStockInfo: Record<string, typeof lowStockVariants[0]> = {}
+  for (const lsv of lowStockVariants) {
+    lowStockInfo[lsv.variant_id] = lsv
+  }
+
+  const lowStockVariantIds = new Set(lowStockVariants.map(lsv => lsv.variant_id))
+
+  const filteredProducts = showLowStockOnly
+    ? displayProducts.filter(p =>
+        (variantsByProduct[p.id] || []).some(v => lowStockVariantIds.has(v.id))
+      )
+    : displayProducts
+
   const { data: variantsByProduct = {} } = useQuery({
-    queryKey: ['variants-batch', displayProducts.map(p => p.id)],
+    queryKey: ['variants-batch', filteredProducts.map(p => p.id)],
     queryFn: async () => {
       const entries = await Promise.all(
-        displayProducts.map(async (p) => {
+        filteredProducts.map(async (p) => {
           const { variants } = await fetchVariants(p.id)
           return [p.id, variants] as const
         })
       )
       return Object.fromEntries(entries) as Record<string, VariantResponse[]>
     },
-    enabled: displayProducts.length > 0,
+    enabled: filteredProducts.length > 0,
   })
 
   const addItem = useCartStore((s) => s.addItem)
@@ -56,7 +72,7 @@ function POSScreen() {
   const getTotalCents = useCartStore((s) => s.getTotalCents)
 
   const variantToProductName: Record<string, string> = {}
-  for (const product of displayProducts) {
+  for (const product of filteredProducts) {
     const variants = variantsByProduct[product.id] || []
     for (const variant of variants) {
       variantToProductName[variant.id] = product.name
@@ -121,12 +137,27 @@ function POSScreen() {
         />
       )}
       <FavoritesBar />
+      <div className="px-4 py-2 flex items-center justify-between border-b">
+        <Button
+          variant={showLowStockOnly ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setShowLowStockOnly(!showLowStockOnly)}
+        >
+          {showLowStockOnly ? 'Showing Low Stock' : 'Show Low Stock'}
+          {lowStockVariants.length > 0 && (
+            <span className="ml-1 px-1.5 py-0.5 rounded-full text-xs bg-amber-100 text-amber-800">
+              {lowStockVariants.length}
+            </span>
+          )}
+        </Button>
+      </div>
       <div className="flex-1 overflow-y-auto pb-20">
         <ProductGrid
-          products={displayProducts}
+          products={filteredProducts}
           variantsByProduct={variantsByProduct}
           onAddToCart={handleAddToCart}
           isLoading={isLoading}
+          lowStockInfo={lowStockInfo}
         />
       </div>
       <CartSummaryBar


### PR DESCRIPTION
## Description

Implemented the low stock alert system with configurable thresholds.

## Changes

### Backend
- Added `low_stock_threshold` to variants table (default 10)
- Added new endpoint `GET /inventory/low-stock?threshold=X`
- Updated variant endpoints to manage the threshold

### Frontend
- Added `LowStockBadge` component for visual indication
- Added "Show Low Stock" toggle filter in POS product grid
- Created `useLowStockVariants` hook