### PR TITLE
feat: add ERP user management

### DIFF
--- a/cmd/server/bootstrap.go
+++ b/cmd/server/bootstrap.go
@@ -105,6 +105,13 @@ func buildRouter(pool *pgxpool.Pool) chi.Router {
 	reportingHandler := reporting.NewHandler(reportingService)
 	protected.Mount("/reports", reportingHandler.Routes())
 
+	// User management routes (owner-only, requires auth middleware)
+	usersRouter := authHandler.UsersRouter()
+	protected.Group(func(r chi.Router) {
+		r.Use(appmiddleware.RequireRole("owner"))
+		r.Mount("/users", usersRouter)
+	})
+
 	r.Mount("/api", protected)
 	return r
 }

--- a/db/migrations/012_add_user_active_flag.down.sql
+++ b/db/migrations/012_add_user_active_flag.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+DROP COLUMN is_active;

--- a/db/migrations/012_add_user_active_flag.up.sql
+++ b/db/migrations/012_add_user_active_flag.up.sql
@@ -1,0 +1,6 @@
+-- Add is_active flag for user management
+ALTER TABLE users
+ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT true;
+
+-- Update existing users to active
+UPDATE users SET is_active = true WHERE is_active IS NULL;

--- a/db/queries/auth.sql
+++ b/db/queries/auth.sql
@@ -4,22 +4,22 @@ VALUES ($1, $2, $3, $4, $5)
 RETURNING id, email, role, name, is_active, created_at, updated_at;
 
 -- name: GetUserByEmail :one
-SELECT id, email, password_hash, role, name, created_at, updated_at, pin_hash
+SELECT id, email, password_hash, role, name, created_at, updated_at, pin_hash, is_active
 FROM users
 WHERE email = $1;
 
 -- name: GetUserByPIN :one
-SELECT id, email, password_hash, role, name, created_at, updated_at, pin_hash
+SELECT id, email, password_hash, role, name, created_at, updated_at, pin_hash, is_active
 FROM users
 WHERE email = $1 AND pin_hash = $2;
 
 -- name: GetUserByID :one
-SELECT id, email, password_hash, role, name, created_at, updated_at, pin_hash
+SELECT id, email, password_hash, role, name, created_at, updated_at, pin_hash, is_active
 FROM users
 WHERE id = $1;
 
 -- name: ListCashiers :many
-SELECT id, email, role, name, created_at, updated_at, pin_hash
+SELECT id, email, role, name, created_at, updated_at, pin_hash, is_active
 FROM users
 WHERE role = 'cashier'
 ORDER BY created_at DESC;

--- a/db/queries/auth.sql
+++ b/db/queries/auth.sql
@@ -1,7 +1,7 @@
 -- name: CreateUser :one
 INSERT INTO users (email, password_hash, role, name, pin_hash)
 VALUES ($1, $2, $3, $4, $5)
-RETURNING id, email, role, name, created_at, updated_at;
+RETURNING id, email, role, name, is_active, created_at, updated_at;
 
 -- name: GetUserByEmail :one
 SELECT id, email, password_hash, role, name, created_at, updated_at, pin_hash
@@ -29,3 +29,20 @@ UPDATE users
 SET pin_hash = $2, updated_at = CURRENT_TIMESTAMP
 WHERE id = $1
 RETURNING id, email, role, name, updated_at;
+
+-- name: ListUsers :many
+SELECT id, email, role, name, is_active, created_at, updated_at
+FROM users
+ORDER BY created_at DESC;
+
+-- name: UpdateUser :one
+UPDATE users
+SET email = $2, name = $3, role = $4, updated_at = CURRENT_TIMESTAMP
+WHERE id = $1
+RETURNING id, email, role, name, is_active, created_at, updated_at;
+
+-- name: ToggleUserActive :one
+UPDATE users
+SET is_active = NOT is_active, updated_at = CURRENT_TIMESTAMP
+WHERE id = $1
+RETURNING id, email, role, name, is_active, created_at, updated_at;

--- a/db/queries/sales.sql
+++ b/db/queries/sales.sql
@@ -2,7 +2,7 @@
 INSERT INTO orders (client_uuid, user_id, status, total_amount, discount_amount)
 VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (client_uuid) DO NOTHING
-RETURNING id, client_uuid, user_id, status, total_amount, discount_amount, created_at, updated_at;
+RETURNING id, client_uuid, user_id, status, total_amount, created_at, updated_at, discount_amount;
 
 -- name: CreateOrderItem :one
 INSERT INTO order_items (order_id, variant_id, quantity, unit_price, subtotal, cost_at_sale)
@@ -10,17 +10,17 @@ VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING id, order_id, variant_id, quantity, unit_price, subtotal, cost_at_sale, created_at;
 
 -- name: GetOrderByClientUUID :one
-SELECT id, client_uuid, user_id, status, total_amount, discount_amount, created_at, updated_at
+SELECT id, client_uuid, user_id, status, total_amount, created_at, updated_at, discount_amount
 FROM orders
 WHERE client_uuid = $1;
 
 -- name: GetOrderByID :one
-SELECT id, client_uuid, user_id, status, total_amount, discount_amount, created_at, updated_at
+SELECT id, client_uuid, user_id, status, total_amount, created_at, updated_at, discount_amount
 FROM orders
 WHERE id = $1;
 
 -- name: ListOrders :many
-SELECT id, client_uuid, user_id, status, total_amount, discount_amount, created_at, updated_at
+SELECT id, client_uuid, user_id, status, total_amount, created_at, updated_at, discount_amount
 FROM orders
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2;

--- a/db/sqlc/auth.sql.go
+++ b/db/sqlc/auth.sql.go
@@ -57,25 +57,14 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (CreateU
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, email, password_hash, role, name, created_at, updated_at, pin_hash
+SELECT id, email, password_hash, role, name, created_at, updated_at, pin_hash, is_active
 FROM users
 WHERE email = $1
 `
 
-type GetUserByEmailRow struct {
-	ID           pgtype.UUID        `json:"id"`
-	Email        string             `json:"email"`
-	PasswordHash string             `json:"password_hash"`
-	Role         string             `json:"role"`
-	Name         string             `json:"name"`
-	CreatedAt    pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
-	PinHash      pgtype.Text        `json:"pin_hash"`
-}
-
-func (q *Queries) GetUserByEmail(ctx context.Context, email string) (GetUserByEmailRow, error) {
+func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error) {
 	row := q.db.QueryRow(ctx, getUserByEmail, email)
-	var i GetUserByEmailRow
+	var i User
 	err := row.Scan(
 		&i.ID,
 		&i.Email,
@@ -85,30 +74,20 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (GetUserByEm
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.PinHash,
+		&i.IsActive,
 	)
 	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, email, password_hash, role, name, created_at, updated_at, pin_hash
+SELECT id, email, password_hash, role, name, created_at, updated_at, pin_hash, is_active
 FROM users
 WHERE id = $1
 `
 
-type GetUserByIDRow struct {
-	ID           pgtype.UUID        `json:"id"`
-	Email        string             `json:"email"`
-	PasswordHash string             `json:"password_hash"`
-	Role         string             `json:"role"`
-	Name         string             `json:"name"`
-	CreatedAt    pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
-	PinHash      pgtype.Text        `json:"pin_hash"`
-}
-
-func (q *Queries) GetUserByID(ctx context.Context, id pgtype.UUID) (GetUserByIDRow, error) {
+func (q *Queries) GetUserByID(ctx context.Context, id pgtype.UUID) (User, error) {
 	row := q.db.QueryRow(ctx, getUserByID, id)
-	var i GetUserByIDRow
+	var i User
 	err := row.Scan(
 		&i.ID,
 		&i.Email,
@@ -118,12 +97,13 @@ func (q *Queries) GetUserByID(ctx context.Context, id pgtype.UUID) (GetUserByIDR
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.PinHash,
+		&i.IsActive,
 	)
 	return i, err
 }
 
 const getUserByPIN = `-- name: GetUserByPIN :one
-SELECT id, email, password_hash, role, name, created_at, updated_at, pin_hash
+SELECT id, email, password_hash, role, name, created_at, updated_at, pin_hash, is_active
 FROM users
 WHERE email = $1 AND pin_hash = $2
 `
@@ -133,20 +113,9 @@ type GetUserByPINParams struct {
 	PinHash pgtype.Text `json:"pin_hash"`
 }
 
-type GetUserByPINRow struct {
-	ID           pgtype.UUID        `json:"id"`
-	Email        string             `json:"email"`
-	PasswordHash string             `json:"password_hash"`
-	Role         string             `json:"role"`
-	Name         string             `json:"name"`
-	CreatedAt    pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
-	PinHash      pgtype.Text        `json:"pin_hash"`
-}
-
-func (q *Queries) GetUserByPIN(ctx context.Context, arg GetUserByPINParams) (GetUserByPINRow, error) {
+func (q *Queries) GetUserByPIN(ctx context.Context, arg GetUserByPINParams) (User, error) {
 	row := q.db.QueryRow(ctx, getUserByPIN, arg.Email, arg.PinHash)
-	var i GetUserByPINRow
+	var i User
 	err := row.Scan(
 		&i.ID,
 		&i.Email,
@@ -156,12 +125,13 @@ func (q *Queries) GetUserByPIN(ctx context.Context, arg GetUserByPINParams) (Get
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.PinHash,
+		&i.IsActive,
 	)
 	return i, err
 }
 
 const listCashiers = `-- name: ListCashiers :many
-SELECT id, email, role, name, created_at, updated_at, pin_hash
+SELECT id, email, role, name, created_at, updated_at, pin_hash, is_active
 FROM users
 WHERE role = 'cashier'
 ORDER BY created_at DESC
@@ -175,6 +145,7 @@ type ListCashiersRow struct {
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
 	PinHash   pgtype.Text        `json:"pin_hash"`
+	IsActive  bool               `json:"is_active"`
 }
 
 func (q *Queries) ListCashiers(ctx context.Context) ([]ListCashiersRow, error) {
@@ -194,6 +165,7 @@ func (q *Queries) ListCashiers(ctx context.Context) ([]ListCashiersRow, error) {
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.PinHash,
+			&i.IsActive,
 		); err != nil {
 			return nil, err
 		}

--- a/db/sqlc/auth.sql.go
+++ b/db/sqlc/auth.sql.go
@@ -14,7 +14,7 @@ import (
 const createUser = `-- name: CreateUser :one
 INSERT INTO users (email, password_hash, role, name, pin_hash)
 VALUES ($1, $2, $3, $4, $5)
-RETURNING id, email, role, name, created_at, updated_at
+RETURNING id, email, role, name, is_active, created_at, updated_at
 `
 
 type CreateUserParams struct {
@@ -30,6 +30,7 @@ type CreateUserRow struct {
 	Email     string             `json:"email"`
 	Role      string             `json:"role"`
 	Name      string             `json:"name"`
+	IsActive  bool               `json:"is_active"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
 }
@@ -48,6 +49,7 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (CreateU
 		&i.Email,
 		&i.Role,
 		&i.Name,
+		&i.IsActive,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -60,9 +62,20 @@ FROM users
 WHERE email = $1
 `
 
-func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error) {
+type GetUserByEmailRow struct {
+	ID           pgtype.UUID        `json:"id"`
+	Email        string             `json:"email"`
+	PasswordHash string             `json:"password_hash"`
+	Role         string             `json:"role"`
+	Name         string             `json:"name"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	PinHash      pgtype.Text        `json:"pin_hash"`
+}
+
+func (q *Queries) GetUserByEmail(ctx context.Context, email string) (GetUserByEmailRow, error) {
 	row := q.db.QueryRow(ctx, getUserByEmail, email)
-	var i User
+	var i GetUserByEmailRow
 	err := row.Scan(
 		&i.ID,
 		&i.Email,
@@ -82,9 +95,20 @@ FROM users
 WHERE id = $1
 `
 
-func (q *Queries) GetUserByID(ctx context.Context, id pgtype.UUID) (User, error) {
+type GetUserByIDRow struct {
+	ID           pgtype.UUID        `json:"id"`
+	Email        string             `json:"email"`
+	PasswordHash string             `json:"password_hash"`
+	Role         string             `json:"role"`
+	Name         string             `json:"name"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	PinHash      pgtype.Text        `json:"pin_hash"`
+}
+
+func (q *Queries) GetUserByID(ctx context.Context, id pgtype.UUID) (GetUserByIDRow, error) {
 	row := q.db.QueryRow(ctx, getUserByID, id)
-	var i User
+	var i GetUserByIDRow
 	err := row.Scan(
 		&i.ID,
 		&i.Email,
@@ -109,9 +133,20 @@ type GetUserByPINParams struct {
 	PinHash pgtype.Text `json:"pin_hash"`
 }
 
-func (q *Queries) GetUserByPIN(ctx context.Context, arg GetUserByPINParams) (User, error) {
+type GetUserByPINRow struct {
+	ID           pgtype.UUID        `json:"id"`
+	Email        string             `json:"email"`
+	PasswordHash string             `json:"password_hash"`
+	Role         string             `json:"role"`
+	Name         string             `json:"name"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	PinHash      pgtype.Text        `json:"pin_hash"`
+}
+
+func (q *Queries) GetUserByPIN(ctx context.Context, arg GetUserByPINParams) (GetUserByPINRow, error) {
 	row := q.db.QueryRow(ctx, getUserByPIN, arg.Email, arg.PinHash)
-	var i User
+	var i GetUserByPINRow
 	err := row.Scan(
 		&i.ID,
 		&i.Email,
@@ -168,6 +203,126 @@ func (q *Queries) ListCashiers(ctx context.Context) ([]ListCashiersRow, error) {
 		return nil, err
 	}
 	return items, nil
+}
+
+const listUsers = `-- name: ListUsers :many
+SELECT id, email, role, name, is_active, created_at, updated_at
+FROM users
+ORDER BY created_at DESC
+`
+
+type ListUsersRow struct {
+	ID        pgtype.UUID        `json:"id"`
+	Email     string             `json:"email"`
+	Role      string             `json:"role"`
+	Name      string             `json:"name"`
+	IsActive  bool               `json:"is_active"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+}
+
+func (q *Queries) ListUsers(ctx context.Context) ([]ListUsersRow, error) {
+	rows, err := q.db.Query(ctx, listUsers)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListUsersRow
+	for rows.Next() {
+		var i ListUsersRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Email,
+			&i.Role,
+			&i.Name,
+			&i.IsActive,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const toggleUserActive = `-- name: ToggleUserActive :one
+UPDATE users
+SET is_active = NOT is_active, updated_at = CURRENT_TIMESTAMP
+WHERE id = $1
+RETURNING id, email, role, name, is_active, created_at, updated_at
+`
+
+type ToggleUserActiveRow struct {
+	ID        pgtype.UUID        `json:"id"`
+	Email     string             `json:"email"`
+	Role      string             `json:"role"`
+	Name      string             `json:"name"`
+	IsActive  bool               `json:"is_active"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+}
+
+func (q *Queries) ToggleUserActive(ctx context.Context, id pgtype.UUID) (ToggleUserActiveRow, error) {
+	row := q.db.QueryRow(ctx, toggleUserActive, id)
+	var i ToggleUserActiveRow
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.Role,
+		&i.Name,
+		&i.IsActive,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const updateUser = `-- name: UpdateUser :one
+UPDATE users
+SET email = $2, name = $3, role = $4, updated_at = CURRENT_TIMESTAMP
+WHERE id = $1
+RETURNING id, email, role, name, is_active, created_at, updated_at
+`
+
+type UpdateUserParams struct {
+	ID    pgtype.UUID `json:"id"`
+	Email string      `json:"email"`
+	Name  string      `json:"name"`
+	Role  string      `json:"role"`
+}
+
+type UpdateUserRow struct {
+	ID        pgtype.UUID        `json:"id"`
+	Email     string             `json:"email"`
+	Role      string             `json:"role"`
+	Name      string             `json:"name"`
+	IsActive  bool               `json:"is_active"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+}
+
+func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) (UpdateUserRow, error) {
+	row := q.db.QueryRow(ctx, updateUser,
+		arg.ID,
+		arg.Email,
+		arg.Name,
+		arg.Role,
+	)
+	var i UpdateUserRow
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.Role,
+		&i.Name,
+		&i.IsActive,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const updateUserPin = `-- name: UpdateUserPin :one

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -49,9 +49,9 @@ type Order struct {
 	UserID         pgtype.UUID        `json:"user_id"`
 	Status         string             `json:"status"`
 	TotalAmount    int64              `json:"total_amount"`
-	DiscountAmount int64              `json:"discount_amount"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+	DiscountAmount int64              `json:"discount_amount"`
 }
 
 type OrderItem struct {
@@ -95,6 +95,7 @@ type User struct {
 	CreatedAt    pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
 	PinHash      pgtype.Text        `json:"pin_hash"`
+	IsActive     bool               `json:"is_active"`
 }
 
 type Variant struct {

--- a/db/sqlc/sales.sql.go
+++ b/db/sqlc/sales.sql.go
@@ -26,7 +26,18 @@ type CreateOrderParams struct {
 	DiscountAmount int64       `json:"discount_amount"`
 }
 
-func (q *Queries) CreateOrder(ctx context.Context, arg CreateOrderParams) (Order, error) {
+type CreateOrderRow struct {
+	ID             pgtype.UUID        `json:"id"`
+	ClientUuid     string             `json:"client_uuid"`
+	UserID         pgtype.UUID        `json:"user_id"`
+	Status         string             `json:"status"`
+	TotalAmount    int64              `json:"total_amount"`
+	DiscountAmount int64              `json:"discount_amount"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+}
+
+func (q *Queries) CreateOrder(ctx context.Context, arg CreateOrderParams) (CreateOrderRow, error) {
 	row := q.db.QueryRow(ctx, createOrder,
 		arg.ClientUuid,
 		arg.UserID,
@@ -34,7 +45,7 @@ func (q *Queries) CreateOrder(ctx context.Context, arg CreateOrderParams) (Order
 		arg.TotalAmount,
 		arg.DiscountAmount,
 	)
-	var i Order
+	var i CreateOrderRow
 	err := row.Scan(
 		&i.ID,
 		&i.ClientUuid,
@@ -136,9 +147,20 @@ FROM orders
 WHERE client_uuid = $1
 `
 
-func (q *Queries) GetOrderByClientUUID(ctx context.Context, clientUuid string) (Order, error) {
+type GetOrderByClientUUIDRow struct {
+	ID             pgtype.UUID        `json:"id"`
+	ClientUuid     string             `json:"client_uuid"`
+	UserID         pgtype.UUID        `json:"user_id"`
+	Status         string             `json:"status"`
+	TotalAmount    int64              `json:"total_amount"`
+	DiscountAmount int64              `json:"discount_amount"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+}
+
+func (q *Queries) GetOrderByClientUUID(ctx context.Context, clientUuid string) (GetOrderByClientUUIDRow, error) {
 	row := q.db.QueryRow(ctx, getOrderByClientUUID, clientUuid)
-	var i Order
+	var i GetOrderByClientUUIDRow
 	err := row.Scan(
 		&i.ID,
 		&i.ClientUuid,
@@ -158,9 +180,20 @@ FROM orders
 WHERE id = $1
 `
 
-func (q *Queries) GetOrderByID(ctx context.Context, id pgtype.UUID) (Order, error) {
+type GetOrderByIDRow struct {
+	ID             pgtype.UUID        `json:"id"`
+	ClientUuid     string             `json:"client_uuid"`
+	UserID         pgtype.UUID        `json:"user_id"`
+	Status         string             `json:"status"`
+	TotalAmount    int64              `json:"total_amount"`
+	DiscountAmount int64              `json:"discount_amount"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+}
+
+func (q *Queries) GetOrderByID(ctx context.Context, id pgtype.UUID) (GetOrderByIDRow, error) {
 	row := q.db.QueryRow(ctx, getOrderByID, id)
-	var i Order
+	var i GetOrderByIDRow
 	err := row.Scan(
 		&i.ID,
 		&i.ClientUuid,
@@ -254,15 +287,26 @@ type ListOrdersParams struct {
 	Offset int32 `json:"offset"`
 }
 
-func (q *Queries) ListOrders(ctx context.Context, arg ListOrdersParams) ([]Order, error) {
+type ListOrdersRow struct {
+	ID             pgtype.UUID        `json:"id"`
+	ClientUuid     string             `json:"client_uuid"`
+	UserID         pgtype.UUID        `json:"user_id"`
+	Status         string             `json:"status"`
+	TotalAmount    int64              `json:"total_amount"`
+	DiscountAmount int64              `json:"discount_amount"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+}
+
+func (q *Queries) ListOrders(ctx context.Context, arg ListOrdersParams) ([]ListOrdersRow, error) {
 	rows, err := q.db.Query(ctx, listOrders, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Order
+	var items []ListOrdersRow
 	for rows.Next() {
-		var i Order
+		var i ListOrdersRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.ClientUuid,

--- a/db/sqlc/sales.sql.go
+++ b/db/sqlc/sales.sql.go
@@ -15,7 +15,7 @@ const createOrder = `-- name: CreateOrder :one
 INSERT INTO orders (client_uuid, user_id, status, total_amount, discount_amount)
 VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (client_uuid) DO NOTHING
-RETURNING id, client_uuid, user_id, status, total_amount, discount_amount, created_at, updated_at
+RETURNING id, client_uuid, user_id, status, total_amount, created_at, updated_at, discount_amount
 `
 
 type CreateOrderParams struct {
@@ -26,18 +26,7 @@ type CreateOrderParams struct {
 	DiscountAmount int64       `json:"discount_amount"`
 }
 
-type CreateOrderRow struct {
-	ID             pgtype.UUID        `json:"id"`
-	ClientUuid     string             `json:"client_uuid"`
-	UserID         pgtype.UUID        `json:"user_id"`
-	Status         string             `json:"status"`
-	TotalAmount    int64              `json:"total_amount"`
-	DiscountAmount int64              `json:"discount_amount"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
-}
-
-func (q *Queries) CreateOrder(ctx context.Context, arg CreateOrderParams) (CreateOrderRow, error) {
+func (q *Queries) CreateOrder(ctx context.Context, arg CreateOrderParams) (Order, error) {
 	row := q.db.QueryRow(ctx, createOrder,
 		arg.ClientUuid,
 		arg.UserID,
@@ -45,16 +34,16 @@ func (q *Queries) CreateOrder(ctx context.Context, arg CreateOrderParams) (Creat
 		arg.TotalAmount,
 		arg.DiscountAmount,
 	)
-	var i CreateOrderRow
+	var i Order
 	err := row.Scan(
 		&i.ID,
 		&i.ClientUuid,
 		&i.UserID,
 		&i.Status,
 		&i.TotalAmount,
-		&i.DiscountAmount,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DiscountAmount,
 	)
 	return i, err
 }
@@ -142,67 +131,45 @@ func (q *Queries) CreatePayment(ctx context.Context, arg CreatePaymentParams) (P
 }
 
 const getOrderByClientUUID = `-- name: GetOrderByClientUUID :one
-SELECT id, client_uuid, user_id, status, total_amount, discount_amount, created_at, updated_at
+SELECT id, client_uuid, user_id, status, total_amount, created_at, updated_at, discount_amount
 FROM orders
 WHERE client_uuid = $1
 `
 
-type GetOrderByClientUUIDRow struct {
-	ID             pgtype.UUID        `json:"id"`
-	ClientUuid     string             `json:"client_uuid"`
-	UserID         pgtype.UUID        `json:"user_id"`
-	Status         string             `json:"status"`
-	TotalAmount    int64              `json:"total_amount"`
-	DiscountAmount int64              `json:"discount_amount"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
-}
-
-func (q *Queries) GetOrderByClientUUID(ctx context.Context, clientUuid string) (GetOrderByClientUUIDRow, error) {
+func (q *Queries) GetOrderByClientUUID(ctx context.Context, clientUuid string) (Order, error) {
 	row := q.db.QueryRow(ctx, getOrderByClientUUID, clientUuid)
-	var i GetOrderByClientUUIDRow
+	var i Order
 	err := row.Scan(
 		&i.ID,
 		&i.ClientUuid,
 		&i.UserID,
 		&i.Status,
 		&i.TotalAmount,
-		&i.DiscountAmount,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DiscountAmount,
 	)
 	return i, err
 }
 
 const getOrderByID = `-- name: GetOrderByID :one
-SELECT id, client_uuid, user_id, status, total_amount, discount_amount, created_at, updated_at
+SELECT id, client_uuid, user_id, status, total_amount, created_at, updated_at, discount_amount
 FROM orders
 WHERE id = $1
 `
 
-type GetOrderByIDRow struct {
-	ID             pgtype.UUID        `json:"id"`
-	ClientUuid     string             `json:"client_uuid"`
-	UserID         pgtype.UUID        `json:"user_id"`
-	Status         string             `json:"status"`
-	TotalAmount    int64              `json:"total_amount"`
-	DiscountAmount int64              `json:"discount_amount"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
-}
-
-func (q *Queries) GetOrderByID(ctx context.Context, id pgtype.UUID) (GetOrderByIDRow, error) {
+func (q *Queries) GetOrderByID(ctx context.Context, id pgtype.UUID) (Order, error) {
 	row := q.db.QueryRow(ctx, getOrderByID, id)
-	var i GetOrderByIDRow
+	var i Order
 	err := row.Scan(
 		&i.ID,
 		&i.ClientUuid,
 		&i.UserID,
 		&i.Status,
 		&i.TotalAmount,
-		&i.DiscountAmount,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DiscountAmount,
 	)
 	return i, err
 }
@@ -276,7 +243,7 @@ func (q *Queries) ListOrderItemsByOrderID(ctx context.Context, orderID pgtype.UU
 }
 
 const listOrders = `-- name: ListOrders :many
-SELECT id, client_uuid, user_id, status, total_amount, discount_amount, created_at, updated_at
+SELECT id, client_uuid, user_id, status, total_amount, created_at, updated_at, discount_amount
 FROM orders
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
@@ -287,35 +254,24 @@ type ListOrdersParams struct {
 	Offset int32 `json:"offset"`
 }
 
-type ListOrdersRow struct {
-	ID             pgtype.UUID        `json:"id"`
-	ClientUuid     string             `json:"client_uuid"`
-	UserID         pgtype.UUID        `json:"user_id"`
-	Status         string             `json:"status"`
-	TotalAmount    int64              `json:"total_amount"`
-	DiscountAmount int64              `json:"discount_amount"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
-}
-
-func (q *Queries) ListOrders(ctx context.Context, arg ListOrdersParams) ([]ListOrdersRow, error) {
+func (q *Queries) ListOrders(ctx context.Context, arg ListOrdersParams) ([]Order, error) {
 	rows, err := q.db.Query(ctx, listOrders, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ListOrdersRow
+	var items []Order
 	for rows.Next() {
-		var i ListOrdersRow
+		var i Order
 		if err := rows.Scan(
 			&i.ID,
 			&i.ClientUuid,
 			&i.UserID,
 			&i.Status,
 			&i.TotalAmount,
-			&i.DiscountAmount,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DiscountAmount,
 		); err != nil {
 			return nil, err
 		}

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,26 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        destructive: 'border-transparent bg-destructive/10 text-destructive',
+        outline: 'border-border text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+function Badge({ className, variant, ...props }: React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof badgeVariants>) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />
+}
+
+export { Badge, badgeVariants }

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,7 @@
+import { cn } from '@/lib/utils'
+
+function Label({ className, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) {
+  return <label className={cn('text-sm font-medium leading-none text-foreground', className)} {...props} />
+}
+
+export { Label }

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react'
+import { Select as SelectPrimitive } from '@base-ui/react/select'
+import { Check, ChevronDown } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+const Select = SelectPrimitive.Root
+
+function SelectTrigger({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Trigger>) {
+  return (
+    <SelectPrimitive.Trigger
+      className={cn(
+        'flex h-10 w-full items-center justify-between rounded-card border border-input bg-background px-3 py-2 text-sm text-foreground outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon>
+        <ChevronDown className="h-4 w-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectValue(props: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value {...props} />
+}
+
+function SelectContent({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Popup>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner>
+        <SelectPrimitive.Popup
+          className={cn('z-50 min-w-[8rem] overflow-hidden rounded-card border border-border bg-popover p-1 text-popover-foreground shadow-dialog', className)}
+          {...props}
+        >
+          <SelectPrimitive.List>
+            {children}
+          </SelectPrimitive.List>
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectItem({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      className={cn('relative flex cursor-default select-none items-center rounded-md py-1.5 pl-8 pr-2 text-sm outline-none hover:bg-muted focus:bg-muted data-[disabled]:pointer-events-none data-[disabled]:opacity-50', className)}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>
+        {children}
+      </SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+export { Select, SelectContent, SelectItem, SelectTrigger, SelectValue }

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,7 @@
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('animate-pulse rounded-md bg-muted', className)} {...props} />
+}
+
+export { Skeleton }

--- a/frontend/src/erp/navigation/ErpNav.tsx
+++ b/frontend/src/erp/navigation/ErpNav.tsx
@@ -24,7 +24,7 @@ const navGroups: Array<{ label: string; items: NavItem[] }> = [
     items: [
       { label: 'Sales handoff', icon: ShoppingCart, to: null },
       { label: 'Reports', icon: BarChart3, to: '/erp/reports' },
-      { label: 'Settings', icon: Settings2, to: null },
+      { label: 'Settings', icon: Settings2, to: '/erp/settings' },
     ],
   },
 ]

--- a/frontend/src/erp/settings/SettingsLayout.tsx
+++ b/frontend/src/erp/settings/SettingsLayout.tsx
@@ -1,0 +1,51 @@
+import { type ReactNode } from 'react'
+import { FolderCog, Users, type LucideIcon } from 'lucide-react'
+
+import { buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface SettingsNavItem {
+  label: string
+  icon: LucideIcon
+  to: string
+}
+
+const settingsNavItems: SettingsNavItem[] = [
+  { label: 'User Management', icon: Users, to: '/erp/settings/users' },
+]
+
+export function SettingsLayout({ children }: { children: ReactNode }) {
+  const pathname = typeof window !== 'undefined' ? window.location.pathname : ''
+
+  return (
+    <div className="flex h-full gap-6">
+      <aside className="w-56 shrink-0 space-y-1">
+        <div className="mb-4 flex items-center gap-2 px-3 text-sm font-medium text-muted-foreground">
+          <FolderCog className="h-4 w-4" />
+          Settings
+        </div>
+        {settingsNavItems.map((item) => {
+          const Icon = item.icon
+          const isActive = pathname === item.to || pathname.startsWith(`${item.to}/`)
+
+          return (
+            <a
+              key={item.label}
+              href={item.to}
+              className={cn(
+                buttonVariants({ variant: isActive ? 'secondary' : 'ghost' }),
+                'h-10 w-full justify-start gap-3 rounded-card px-3',
+              )}
+            >
+              <Icon className="h-4 w-4" />
+              {item.label}
+            </a>
+          )
+        })}
+      </aside>
+      <div className="min-w-0 flex-1">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/erp/settings/users/UserFormDialog.tsx
+++ b/frontend/src/erp/settings/users/UserFormDialog.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState, type FormEvent } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  type CreateUserValues,
+  type UpdateUserValues,
+  type UserRecord,
+  useCreateUserMutation,
+  useUpdateUserMutation,
+} from '@/lib/users-api'
+
+interface UserFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  user: UserRecord | null
+}
+
+export function UserFormDialog({ open, onOpenChange, user }: UserFormDialogProps) {
+  const createMutation = useCreateUserMutation()
+  const updateMutation = useUpdateUserMutation()
+  const isEditing = user !== null
+
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState<'owner' | 'cashier'>('cashier')
+  const [password, setPassword] = useState('')
+  const [pin, setPin] = useState('')
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (user) {
+      setName(user.name)
+      setEmail(user.email)
+      setRole(user.role)
+    } else {
+      setName('')
+      setEmail('')
+      setRole('cashier')
+    }
+
+    setPassword('')
+    setPin('')
+    setError('')
+  }, [user, open])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError('')
+
+    const trimmedName = name.trim()
+    const trimmedEmail = email.trim()
+
+    if (!trimmedName || !trimmedEmail) {
+      setError('Name and email are required.')
+      return
+    }
+
+    if (!isEditing && role === 'owner' && !password.trim()) {
+      setError('Password is required for owner users.')
+      return
+    }
+
+    if (!isEditing && role === 'cashier' && !pin.trim()) {
+      setError('PIN is required for cashier users.')
+      return
+    }
+
+    try {
+      if (isEditing && user) {
+        const data: UpdateUserValues = { name: trimmedName, email: trimmedEmail, role }
+        await updateMutation.mutateAsync({ id: user.id, data })
+      } else {
+        const data: CreateUserValues = {
+          name: trimmedName,
+          email: trimmedEmail,
+          role,
+          password,
+          pin,
+        }
+        await createMutation.mutateAsync(data)
+      }
+      onOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred')
+    }
+  }
+
+  const isPending = createMutation.isPending || updateMutation.isPending
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{isEditing ? 'Edit User' : 'Add User'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input id="name" value={name} onChange={(event) => setName(event.target.value)} placeholder="John Doe" />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" type="email" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="john@example.com" />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="role">Role</Label>
+            <select
+              id="role"
+              value={role}
+              onChange={(event) => setRole(event.target.value as 'owner' | 'cashier')}
+              className="flex h-10 w-full rounded-card border border-input bg-background px-3 py-2 text-sm text-foreground outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+            >
+              <option value="owner">Owner</option>
+              <option value="cashier">Cashier</option>
+            </select>
+          </div>
+
+          {!isEditing && role === 'owner' ? (
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input id="password" type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="••••••••" />
+            </div>
+          ) : null}
+
+          {!isEditing && role === 'cashier' ? (
+            <div className="space-y-2">
+              <Label htmlFor="pin">PIN</Label>
+              <Input id="pin" type="password" value={pin} onChange={(event) => setPin(event.target.value)} placeholder="4-6 digits" maxLength={6} />
+            </div>
+          ) : null}
+
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isEditing ? 'Save Changes' : 'Create User'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/erp/settings/users/UserManagementPage.tsx
+++ b/frontend/src/erp/settings/users/UserManagementPage.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react'
+import { Plus, RotateCcw } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/skeleton'
+import { type UserRecord, useToggleUserActiveMutation, useUsersQuery } from '@/lib/users-api'
+
+import { UserFormDialog } from './UserFormDialog'
+
+export function UserManagementPage() {
+  const { data: users = [], isLoading, error } = useUsersQuery()
+  const toggleActiveMutation = useToggleUserActiveMutation()
+  const [searchQuery, setSearchQuery] = useState('')
+  const [userDialogOpen, setUserDialogOpen] = useState(false)
+  const [editingUser, setEditingUser] = useState<UserRecord | null>(null)
+
+  const normalizedSearch = searchQuery.trim().toLowerCase()
+  const filteredUsers = normalizedSearch
+    ? users.filter((user) => (
+      user.name.toLowerCase().includes(normalizedSearch)
+      || user.email.toLowerCase().includes(normalizedSearch)
+    ))
+    : users
+
+  const handleEdit = (user: UserRecord) => {
+    setEditingUser(user)
+    setUserDialogOpen(true)
+  }
+
+  const handleCreate = () => {
+    setEditingUser(null)
+    setUserDialogOpen(true)
+  }
+
+  const handleToggleActive = (userId: string) => {
+    toggleActiveMutation.mutate(userId)
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center text-destructive">
+        Failed to load users. Please try again.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">User Management</h1>
+          <p className="mt-1 text-sm text-muted-foreground">Create owner and cashier accounts, then control access without leaving Settings.</p>
+        </div>
+        <Button onClick={handleCreate}>
+          <Plus className="mr-2 h-4 w-4" />
+          Add User
+        </Button>
+      </div>
+
+      <Input
+        placeholder="Search by name or email..."
+        value={searchQuery}
+        onChange={(event) => setSearchQuery(event.target.value)}
+        className="max-w-sm"
+      />
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <Skeleton key={index} className="h-16 w-full rounded-card" />
+          ))}
+        </div>
+      ) : filteredUsers.length === 0 ? (
+        <div className="flex h-48 items-center justify-center rounded-card border border-dashed border-border text-muted-foreground">
+          {searchQuery ? 'No users match your search.' : 'No users found.'}
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-card border border-border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-muted/50 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                <th className="px-4 py-3">Name</th>
+                <th className="px-4 py-3">Email</th>
+                <th className="px-4 py-3">Role</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredUsers.map((user) => (
+                <tr key={user.id} className="border-b border-border last:border-0 hover:bg-muted/30">
+                  <td className="px-4 py-3 font-medium">{user.name}</td>
+                  <td className="px-4 py-3 text-muted-foreground">{user.email}</td>
+                  <td className="px-4 py-3">
+                    <Badge variant={user.role === 'owner' ? 'default' : 'secondary'}>
+                      {user.role}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3">
+                    <Badge variant={user.is_active ? 'outline' : 'destructive'}>
+                      {user.is_active ? 'Active' : 'Inactive'}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <Button variant="ghost" size="sm" onClick={() => handleEdit(user)}>
+                        Edit
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleToggleActive(user.id)}
+                        disabled={toggleActiveMutation.isPending}
+                      >
+                        <RotateCcw className="mr-1 h-3 w-3" />
+                        {user.is_active ? 'Deactivate' : 'Activate'}
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <UserFormDialog
+        open={userDialogOpen}
+        onOpenChange={setUserDialogOpen}
+        user={editingUser}
+      />
+    </div>
+  )
+}

--- a/frontend/src/lib/users-api.ts
+++ b/frontend/src/lib/users-api.ts
@@ -1,0 +1,93 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { requestJSON } from '@/lib/api'
+
+export interface UserRecord {
+  id: string
+  email: string
+  name: string
+  role: 'owner' | 'cashier'
+  is_active: boolean
+  created_at?: string
+  updated_at?: string
+}
+
+export interface CreateUserValues {
+  email: string
+  password: string
+  name: string
+  role: 'owner' | 'cashier'
+  pin?: string
+}
+
+export interface UpdateUserValues {
+  email: string
+  name: string
+  role: 'owner' | 'cashier'
+}
+
+const usersQueryKey = ['users'] as const
+
+async function listUsers(): Promise<UserRecord[]> {
+  return requestJSON<UserRecord[]>('/api/users')
+}
+
+async function createUser(data: CreateUserValues): Promise<UserRecord> {
+  return requestJSON<UserRecord>('/api/users', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+async function updateUser(id: string, data: UpdateUserValues): Promise<UserRecord> {
+  return requestJSON<UserRecord>(`/api/users/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  })
+}
+
+async function toggleUserActive(id: string): Promise<UserRecord> {
+  return requestJSON<UserRecord>(`/api/users/${id}/toggle-active`, {
+    method: 'PATCH',
+  })
+}
+
+export function useUsersQuery() {
+  return useQuery({
+    queryKey: usersQueryKey,
+    queryFn: listUsers,
+  })
+}
+
+export function useCreateUserMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: createUser,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: usersQueryKey })
+    },
+  })
+}
+
+export function useUpdateUserMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateUserValues }) => updateUser(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: usersQueryKey })
+    },
+  })
+}
+
+export function useToggleUserActiveMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: toggleUserActive,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: usersQueryKey })
+    },
+  })
+}

--- a/frontend/src/routes/erp.settings.tsx
+++ b/frontend/src/routes/erp.settings.tsx
@@ -1,0 +1,19 @@
+import { Outlet, createRoute } from '@tanstack/react-router'
+
+import { SettingsLayout } from '@/erp/settings/SettingsLayout'
+
+import { Route as erpRoute } from './erp'
+
+export const Route = createRoute({
+  getParentRoute: () => erpRoute,
+  path: 'settings',
+  component: SettingsRoute,
+})
+
+function SettingsRoute() {
+  return (
+    <SettingsLayout>
+      <Outlet />
+    </SettingsLayout>
+  )
+}

--- a/frontend/src/routes/erp.settings.users.tsx
+++ b/frontend/src/routes/erp.settings.users.tsx
@@ -1,0 +1,11 @@
+import { createRoute } from '@tanstack/react-router'
+
+import { UserManagementPage } from '@/erp/settings/users/UserManagementPage'
+
+import { Route as settingsRoute } from './erp.settings'
+
+export const Route = createRoute({
+  getParentRoute: () => settingsRoute,
+  path: 'users',
+  component: UserManagementPage,
+})

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -56,6 +56,15 @@ type CreateCashierRequest struct {
 	Name  string `json:"name"`
 }
 
+// CreateUserRequest represents a managed user creation request
+type CreateUserRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+	Name     string `json:"name"`
+	Role     string `json:"role"`
+	PIN      string `json:"pin"`
+}
+
 // UpdateUserRequest represents an update user request
 type UpdateUserRequest struct {
 	Email string `json:"email"`
@@ -185,6 +194,31 @@ func (h *Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(users)
 }
 
+// CreateUser handles POST /api/users (owner only)
+func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
+	actorID := r.Context().Value("user_id")
+	if actorID == nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req CreateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	user, err := h.service.CreateUser(r.Context(), actorID.(string), req.Email, req.Password, req.PIN, req.Name, req.Role)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(user)
+}
+
 // UpdateUser handles PUT /api/users/{id} (owner only)
 func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	actorID := r.Context().Value("user_id")
@@ -244,6 +278,7 @@ func (h *Handler) UsersRouter() *chi.Mux {
 	r := chi.NewRouter()
 
 	r.Get("/", h.ListUsers)
+	r.Post("/", h.CreateUser)
 	r.Put("/{id}", h.UpdateUser)
 	r.Patch("/{id}/toggle-active", h.ToggleUserActive)
 

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -56,6 +56,13 @@ type CreateCashierRequest struct {
 	Name  string `json:"name"`
 }
 
+// UpdateUserRequest represents an update user request
+type UpdateUserRequest struct {
+	Email string `json:"email"`
+	Name  string `json:"name"`
+	Role  string `json:"role"`
+}
+
 // AuthResponse represents an authentication response
 type AuthResponse struct {
 	User  *User  `json:"user"`
@@ -164,4 +171,81 @@ func (h *Handler) ListCashiers(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(cashiers)
+}
+
+// ListUsers handles GET /api/users (owner only)
+func (h *Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
+	users, err := h.service.ListUsers(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(users)
+}
+
+// UpdateUser handles PUT /api/users/{id} (owner only)
+func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
+	actorID := r.Context().Value("user_id")
+	if actorID == nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	userID := chi.URLParam(r, "id")
+	if userID == "" {
+		http.Error(w, "missing user id", http.StatusBadRequest)
+		return
+	}
+
+	var req UpdateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	user, err := h.service.UpdateUser(r.Context(), actorID.(string), userID, req.Email, req.Name, req.Role)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(user)
+}
+
+// ToggleUserActive handles PATCH /api/users/{id}/toggle-active (owner only)
+func (h *Handler) ToggleUserActive(w http.ResponseWriter, r *http.Request) {
+	actorID := r.Context().Value("user_id")
+	if actorID == nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	userID := chi.URLParam(r, "id")
+	if userID == "" {
+		http.Error(w, "missing user id", http.StatusBadRequest)
+		return
+	}
+
+	user, err := h.service.ToggleUserActive(r.Context(), actorID.(string), userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(user)
+}
+
+// UsersRouter returns the chi router for user management endpoints (owner-only)
+func (h *Handler) UsersRouter() *chi.Mux {
+	r := chi.NewRouter()
+
+	r.Get("/", h.ListUsers)
+	r.Put("/{id}", h.UpdateUser)
+	r.Patch("/{id}/toggle-active", h.ToggleUserActive)
+
+	return r
 }

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1,0 +1,33 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestUsersRouterRoutes(t *testing.T) {
+	handler := NewHandler(nil)
+	router := handler.UsersRouter()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "list users", method: http.MethodGet, path: "/"},
+		{name: "create user", method: http.MethodPost, path: "/"},
+		{name: "update user", method: http.MethodPut, path: "/user-id"},
+		{name: "toggle active", method: http.MethodPatch, path: "/user-id/toggle-active"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rctx := chi.NewRouteContext()
+			if !router.Match(rctx, tt.method, tt.path) {
+				t.Fatalf("expected %s %s to be routed", tt.method, tt.path)
+			}
+		})
+	}
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -22,10 +22,11 @@ var (
 
 // User represents an authenticated user
 type User struct {
-	ID    string
-	Email string
-	Role  string
-	Name  string
+	ID       string `json:"id"`
+	Email    string `json:"email"`
+	Role     string `json:"role"`
+	Name     string `json:"name"`
+	IsActive bool   `json:"is_active"`
 }
 
 // TokenClaims represents JWT claims
@@ -78,10 +79,11 @@ func (s *AuthService) RegisterOwner(ctx context.Context, email, password, name s
 	}
 
 	return &User{
-		ID:    user.ID.String(),
-		Email: user.Email,
-		Role:  user.Role,
-		Name:  user.Name,
+		ID:       user.ID.String(),
+		Email:    user.Email,
+		Role:     user.Role,
+		Name:     user.Name,
+		IsActive: user.IsActive,
 	}, nil
 }
 
@@ -91,6 +93,11 @@ func (s *AuthService) Login(ctx context.Context, email, password string) (*User,
 	user, err := s.queries.GetUserByEmail(ctx, email)
 	if err != nil {
 		return nil, "", ErrInvalidCredentials
+	}
+
+	// Verify user is active
+	if !user.IsActive {
+		return nil, "", ErrUnauthorized
 	}
 
 	// Verify password
@@ -105,10 +112,11 @@ func (s *AuthService) Login(ctx context.Context, email, password string) (*User,
 	}
 
 	return &User{
-		ID:    user.ID.String(),
-		Email: user.Email,
-		Role:  user.Role,
-		Name:  user.Name,
+		ID:       user.ID.String(),
+		Email:    user.Email,
+		Role:     user.Role,
+		Name:     user.Name,
+		IsActive: user.IsActive,
 	}, token, nil
 }
 
@@ -118,6 +126,11 @@ func (s *AuthService) LoginWithPIN(ctx context.Context, email, pin string) (*Use
 	user, err := s.queries.GetUserByEmail(ctx, email)
 	if err != nil {
 		return nil, "", ErrInvalidCredentials
+	}
+
+	// Verify user is active
+	if !user.IsActive {
+		return nil, "", ErrUnauthorized
 	}
 
 	// Verify user is a cashier
@@ -140,10 +153,11 @@ func (s *AuthService) LoginWithPIN(ctx context.Context, email, pin string) (*Use
 	}
 
 	return &User{
-		ID:    user.ID.String(),
-		Email: user.Email,
-		Role:  user.Role,
-		Name:  user.Name,
+		ID:       user.ID.String(),
+		Email:    user.Email,
+		Role:     user.Role,
+		Name:     user.Name,
+		IsActive: user.IsActive,
 	}, token, nil
 }
 
@@ -187,10 +201,11 @@ func (s *AuthService) CreateCashier(ctx context.Context, ownerID, email, pin, na
 	}
 
 	return &User{
-		ID:    user.ID.String(),
-		Email: user.Email,
-		Role:  user.Role,
-		Name:  user.Name,
+		ID:       user.ID.String(),
+		Email:    user.Email,
+		Role:     user.Role,
+		Name:     user.Name,
+		IsActive: user.IsActive,
 	}, nil
 }
 
@@ -207,10 +222,11 @@ func (s *AuthService) GetUserByID(ctx context.Context, userID string) (*User, er
 	}
 
 	return &User{
-		ID:    user.ID.String(),
-		Email: user.Email,
-		Role:  user.Role,
-		Name:  user.Name,
+		ID:       user.ID.String(),
+		Email:    user.Email,
+		Role:     user.Role,
+		Name:     user.Name,
+		IsActive: user.IsActive,
 	}, nil
 }
 
@@ -224,14 +240,109 @@ func (s *AuthService) ListCashiers(ctx context.Context) ([]User, error) {
 	users := make([]User, len(cashiers))
 	for i, c := range cashiers {
 		users[i] = User{
-			ID:    c.ID.String(),
-			Email: c.Email,
-			Role:  c.Role,
-			Name:  c.Name,
+			ID:       c.ID.String(),
+			Email:    c.Email,
+			Role:     c.Role,
+			Name:     c.Name,
+			IsActive: c.IsActive,
 		}
 	}
 
 	return users, nil
+}
+
+// ListUsers returns all users (owner only)
+func (s *AuthService) ListUsers(ctx context.Context) ([]User, error) {
+	users, err := s.queries.ListUsers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]User, len(users))
+	for i, u := range users {
+		result[i] = User{
+			ID:       u.ID.String(),
+			Email:    u.Email,
+			Role:     u.Role,
+			Name:     u.Name,
+			IsActive: u.IsActive,
+		}
+	}
+
+	return result, nil
+}
+
+// UpdateUser updates a user's email, name, and role (owner only)
+func (s *AuthService) UpdateUser(ctx context.Context, actorID, userID, email, name, role string) (*User, error) {
+	// Parse UUIDs
+	userUUID, err := parseUUID(userID)
+	if err != nil {
+		return nil, ErrUnauthorized
+	}
+
+	// Prevent changing own role or deactivating self
+	actorUUID, err := parseUUID(actorID)
+	if err != nil {
+		return nil, ErrUnauthorized
+	}
+
+	if actorUUID == userUUID {
+		return nil, errors.New("cannot change your own account from user management")
+	}
+
+	// Validate role
+	if role != "owner" && role != "cashier" {
+		return nil, errors.New("invalid role: must be 'owner' or 'cashier'")
+	}
+
+	user, err := s.queries.UpdateUser(ctx, sqlc.UpdateUserParams{
+		ID:    userUUID,
+		Email: email,
+		Name:  name,
+		Role:  role,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &User{
+		ID:       user.ID.String(),
+		Email:    user.Email,
+		Role:     user.Role,
+		Name:     user.Name,
+		IsActive: user.IsActive,
+	}, nil
+}
+
+// ToggleUserActive toggles the is_active flag on a user (owner only)
+func (s *AuthService) ToggleUserActive(ctx context.Context, actorID, userID string) (*User, error) {
+	userUUID, err := parseUUID(userID)
+	if err != nil {
+		return nil, ErrUnauthorized
+	}
+
+	// Prevent deactivating self
+	actorUUID, err := parseUUID(actorID)
+	if err != nil {
+		return nil, ErrUnauthorized
+	}
+
+	if actorUUID == userUUID {
+		return nil, errors.New("cannot deactivate your own account")
+	}
+
+	user, err := s.queries.ToggleUserActive(ctx, userUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &User{
+		ID:       user.ID.String(),
+		Email:    user.Email,
+		Role:     user.Role,
+		Name:     user.Name,
+		IsActive: user.IsActive,
+	}, nil
 }
 
 // ValidateToken validates a JWT token and returns the user

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/zestzero/openpos/db/sqlc"
@@ -270,6 +270,74 @@ func (s *AuthService) ListUsers(ctx context.Context) ([]User, error) {
 	}
 
 	return result, nil
+}
+
+// CreateUser creates a managed owner or cashier user (owner only)
+func (s *AuthService) CreateUser(ctx context.Context, actorID, email, password, pin, name, role string) (*User, error) {
+	actorUUID, err := parseUUID(actorID)
+	if err != nil {
+		return nil, ErrUnauthorized
+	}
+
+	actor, err := s.queries.GetUserByID(ctx, actorUUID)
+	if err != nil {
+		return nil, ErrUnauthorized
+	}
+
+	if actor.Role != "owner" {
+		return nil, ErrForbidden
+	}
+
+	if role != "owner" && role != "cashier" {
+		return nil, errors.New("invalid role: must be 'owner' or 'cashier'")
+	}
+
+	params := sqlc.CreateUserParams{
+		Email: email,
+		Role:  role,
+		Name:  name,
+	}
+
+	if role == "owner" {
+		if password == "" {
+			return nil, errors.New("password is required for owner users")
+		}
+
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+		if err != nil {
+			return nil, err
+		}
+
+		params.PasswordHash = string(hashedPassword)
+	} else {
+		if pin == "" {
+			return nil, errors.New("pin is required for cashier users")
+		}
+
+		hashedPIN, err := bcrypt.GenerateFromPassword([]byte(pin), bcrypt.DefaultCost)
+		if err != nil {
+			return nil, err
+		}
+
+		params.PasswordHash = ""
+		params.PinHash = pgtype.Text{
+			String: string(hashedPIN),
+			Valid:  true,
+		}
+	}
+
+	user, err := s.queries.CreateUser(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return &User{
+		ID:       user.ID.String(),
+		Email:    user.Email,
+		Role:     user.Role,
+		Name:     user.Name,
+		IsActive: user.IsActive,
+	}, nil
 }
 
 // UpdateUser updates a user's email, name, and role (owner only)


### PR DESCRIPTION
## Summary
- Add user active flag, sqlc queries, service methods, and owner-only /api/users management endpoints
- Add Settings > User Management routes, API hooks, user table, and create/edit dialog
- Link ERP Settings nav item to the new settings layout

## Test Plan
- go test ./...
- npm run build (frontend)

## Notes
- Frontend build reports existing Vite warnings for html5-qrcode dynamic import and large chunks.